### PR TITLE
Use C++ random number generation

### DIFF
--- a/src/kaczmarz_example.cpp
+++ b/src/kaczmarz_example.cpp
@@ -2,6 +2,7 @@
 #include "kaczmarz.hpp"
 
 #include <iostream>
+#include <random>
 
 //this is an example, demonstrating how to call the kaczmarz solver (serial version) on a randomly generated dense matrix
 
@@ -12,8 +13,8 @@ int main() {
   double *b = (double *)malloc(sizeof(double)*dim);
   double *x = (double *)malloc(sizeof(double)*dim);
   
-  std::srand(21);
-  generate_random_dense_linear_system(A, b, x, dim);
+  std::mt19937 rng(21);
+  generate_random_dense_linear_system(rng, A, b, x, dim);
 
 
   double *x_kaczmarz = (double *)malloc(sizeof(double)*dim);

--- a/src/random_dense_system/random_dense_system.cpp
+++ b/src/random_dense_system/random_dense_system.cpp
@@ -1,20 +1,21 @@
 #include "random_dense_system.hpp"
 
 #include <Eigen/Dense>
+#include <algorithm>
+#include <random>
 
-void generate_random_dense_linear_system(double* A, double* b, double* x, unsigned dim){//seeding should be done once in main function!
+void generate_random_dense_linear_system(std::mt19937& rng, double* A, double* b, double* x, unsigned dim){
   
   Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> A_m(A, dim, dim);
   Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> b_m(b, dim);
   Eigen::Map<Eigen::Vector<double, Eigen::Dynamic>> x_m(x, dim);
+
+  std::uniform_real_distribution<> dist(-1.0, 1.0);
+  const auto generate_element = [&dist, &rng]() { return dist(rng); };
   
   do {
-    for (int i = 0; i < dim; i++){
-      for (int j = 0; j < dim; j++){
-         A_m(i,j) = static_cast<double>(std::rand())/RAND_MAX;
-      }
-      b_m(i) = static_cast<double>(std::rand())/RAND_MAX;
-    }
+    std::generate_n(A, dim * dim, generate_element);
+    std::generate_n(b, dim, generate_element);
   } while (A_m.fullPivLu().rank() != dim); // check if matrix is full-rank (will be full-rank practically always, but still)
   
   x_m = A_m.fullPivLu().solve(b_m);

--- a/src/random_dense_system/random_dense_system.hpp
+++ b/src/random_dense_system/random_dense_system.hpp
@@ -2,10 +2,9 @@
 #define RANDOM_DENSE_SYS_HPP
 
 
-/**
- * To get deterministic results, seed with std::srand before calling this function.
- */
-void generate_random_dense_linear_system(double* A, double* b, double* x, unsigned dim);
+#include <random>
+
+void generate_random_dense_linear_system(std::mt19937& rng, double* A, double* b, double* x, unsigned dim);
 
 
 #endif // RANDOM_DENSE_SYS_HPP

--- a/src/testing.cpp
+++ b/src/testing.cpp
@@ -4,17 +4,19 @@
 #include "gtest/gtest.h"
 #include <cmath>
 #include <cstring>
+#include <random>
 
 #define MAX_IT 1000000
 #define RUNS_PER_DIM 5
 
 void run_random_system_tests(const unsigned dim, const unsigned no_runs) {
+  std::mt19937 rng(21);
   for (int i = 0; i < no_runs; i++){
     double *A = (double *)malloc(sizeof(double)*dim*dim);
     double *b = (double *)malloc(sizeof(double)*dim);
     double *x = (double *)malloc(sizeof(double)*dim);
     
-    generate_random_dense_linear_system(A, b, x, dim); //get randomised system
+    generate_random_dense_linear_system(rng, A, b, x, dim); //get randomised system
 
     double *x_kaczmarz = (double *)malloc(sizeof(double)*dim);
     std::memset(x_kaczmarz, 0, sizeof(double) * dim);
@@ -48,7 +50,6 @@ TEST(KaczmarzSerialDenseCorrectnessLarge, AgreesWithEigen){
 }
 
 int main() {
-  std::srand(21);
   testing::InitGoogleTest();
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Now using C++ utilities for generating random numbers. Their advantages compared to C's `rand` / `srand` are, for example,
* random number generator's state is not global; instead, each `std::mt19937` generator in C++ has its own state
* direct support for sampling common distributions (such as, in our case, the uniform distribution of doubles between -1 and 1)