### PR TITLE
modify python script to plot all data

### DIFF
--- a/kaczmarz/src/plot.py
+++ b/kaczmarz/src/plot.py
@@ -7,13 +7,13 @@ data_sparse_sparse = pd.read_csv("results_sparsesolver_sparse.csv")
 data_random_dense = pd.read_csv("results_randomsolver_dense.csv")
 
 # Create the plot with error bars and connected lines
-plt.errorbar(data1["Dim"], data1["AvgTime"], yerr=data1["StdDev"], fmt='o-', capsize=5, label="Normal Solver Dense")
+plt.errorbar(data_normal_dense["Dim"], data_normal_dense["AvgTime"], yerr=data_normal_dense["StdDev"], fmt='o-', capsize=5, label="Normal Solver Dense")
 
 # Create the plot with error bars and connected lines
-plt.errorbar(data2["Dim"], data2["AvgTime"], yerr=data2["StdDev"], fmt='o-', capsize=5, label="Sparse Solver Sparse")
+plt.errorbar(data_sparse_sparse["Dim"], data_sparse_sparse["AvgTime"], yerr=data_sparse_sparse["StdDev"], fmt='o-', capsize=5, label="Sparse Solver Sparse")
 
 # Create the plot with error bars and connected lines
-plt.errorbar(data3["Dim"], data3["AvgTime"], yerr=data3["StdDev"], fmt='o-', capsize=5, label="Random Solver Dense")
+plt.errorbar(data_random_dense["Dim"], data_random_dense["AvgTime"], yerr=data_random_dense["StdDev"], fmt='o-', capsize=5, label="Random Solver Dense")
 
 
 # Set labels and title


### PR DESCRIPTION
Added all 3 benchmarked solvers to be plotted on the same graph. Maybe at some point we still could only compare dense stuff with dense stuff and sparse stuff with sparse stuff and/or compare the parallelized stuff only with its serialized stuff. I don't think we should have them all in one graph. But I would suggest to discuss this once we have a parallelized version.