### PR TITLE
Cleanup CMake; Reduce Number of Warnings Printed

### DIFF
--- a/kaczmarz/CMakeLists.txt
+++ b/kaczmarz/CMakeLists.txt
@@ -13,9 +13,7 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 20)
 
 # Enable all warnings and extra warnings
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -fopenmp -pthread")
-
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -lcusparse -lcudss")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -fopenmp")
 
 #################################
 ## Download dependencies


### PR DESCRIPTION
The only change in behavior should be that there are now fewer warnings when building

@cedriczeiter Could you just make sure that it builds fine on your machine with these changes?